### PR TITLE
newly cloned project fails file upload as there is no photo-storage directory in public

### DIFF
--- a/public/photo-storage/.gitignore
+++ b/public/photo-storage/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Hi, thanks for the demo code! I was using it and noticed that the newly cloned project will fail to upload files as the public/photo-storage directory does not exist in the repo. To fix this I simply added a .gitignore file to make sure the directory is added to the repo, but all uploaded photo files will be ignored